### PR TITLE
install GitHub Copilot and fix warnings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,12 +6,17 @@
       "DOCKER_BUILDKIT": "1"
     }
   },
-  "extensions": [
-    "EditorConfig.EditorConfig",
-    "rebornix.Ruby",
-    "castwide.solargraph",
-    "kaiwood.endwise"
-  ],
-	"workspaceFolder": "/home/vscode/coding",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "EditorConfig.EditorConfig",
+        "rebornix.Ruby",
+        "castwide.solargraph",
+        "kaiwood.endwise",
+        "GitHub.copilot"
+      ]
+    }
+  },
+  "workspaceFolder": "/home/vscode/coding",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/vscode/coding,type=bind"
 }


### PR DESCRIPTION
```
# warning 1
[{
	"resource": "/home/vscode/coding/.devcontainer/devcontainer.json",
	"owner": "_generated_diagnostic_collection_name_#1",
	"severity": 4,
	"message": "Property extensions is not allowed.",
	"startLineNumber": 9,
	"startColumn": 3,
	"endLineNumber": 9,
	"endColumn": 15
}]

# warning 2
[{
	"resource": "/home/vscode/coding/.devcontainer/devcontainer.json",
	"owner": "_generated_diagnostic_collection_name_#1",
	"code": "2",
	"severity": 4,
	"message": "Use 'customizations/vscode/extensions' instead",
	"startLineNumber": 9,
	"startColumn": 3,
	"endLineNumber": 15,
	"endColumn": 4
}]
```